### PR TITLE
ensure orig is not nil

### DIFF
--- a/1509281047.thing-at-point-url-at-point-ffap.org
+++ b/1509281047.thing-at-point-url-at-point-ffap.org
@@ -42,7 +42,7 @@ thing-at-point--bounds-of-well-formed-url 関数が絡んでいます。
 (require 'thingatpt)
 (defun thing-at-point--bounds-of-well-formed-url--strip-last-apostrophe (&rest them)
   (let ((orig (apply them)))
-    (if (memq (char-before (cdr orig)) '(?'))
+    (if (and orig (memq (char-before (cdr orig)) '(?')))
         (cons (car orig) (1- (cdr orig)))
       orig)))
 (advice-add 'thing-at-point--bounds-of-well-formed-url :around


### PR DESCRIPTION
When do `ffap` on the `'thingatpt`, orig has been nil.
emacs-version: GNU Emacs 24.5.1 (i686-pc-cygwin) of 2015-06-23 on desktop-new
